### PR TITLE
Fix chat service test

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -533,5 +533,3 @@ Contact previous teams for testing, deployment and issues related to following f
 3. Job Posting -> quanqi-hu@tamu.edu
 4. CRM -> jubey.s.garza@tamu.edu
 5. General -> sknc@tamu.edu
-T e s t i n g   G i t H u b   A c t i o n s  
- 

--- a/README.MD
+++ b/README.MD
@@ -533,3 +533,5 @@ Contact previous teams for testing, deployment and issues related to following f
 3. Job Posting -> quanqi-hu@tamu.edu
 4. CRM -> jubey.s.garza@tamu.edu
 5. General -> sknc@tamu.edu
+T e s t i n g   G i t H u b   A c t i o n s  
+ 

--- a/spec/controllers/chat_controller_spec.rb
+++ b/spec/controllers/chat_controller_spec.rb
@@ -1,9 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe ChatController, type: :controller do
-    describe "POST#chat" do
-        it 'sends a new message to the AI chat bot' do
-            post :chat, params: {user_input: "Hello"}
-        end
+  describe "POST#chat" do
+    it 'sends a new message to the AI chat bot and validates the response body' do
+      # Mock the ChatService to avoid making actual API requests
+      chat_service = instance_double("ChatService")
+      
+      # Mocking the response that would come from the API, simulating a valid response structure
+      # even if the content might reflect an invalid API key or other errors
+      allow(chat_service).to receive(:call).and_return({
+        "choices" => [
+          {
+            "message" => {
+              "content" => "Invalid API key"
+            }
+          }
+        ]
+      })
+
+      # Trigger the controller action with a valid user_input
+      post :chat, params: { user_input: "Hello" }
+
+      # Parse the response body (you can check the format of the response, e.g., JSON)
+      parsed_response = JSON.parse(response.body)
+
+      # Validate that the response has the expected structure, without checking content
+      expect(parsed_response).to have_key("choices")
+      expect(parsed_response["choices"].first).to have_key("message")
+      expect(parsed_response["choices"].first["message"]).to have_key("content")
+
+      # Additionally, check that the HTTP status is successful (200)
+      expect(response).to have_http_status(:success)
     end
+  end
 end


### PR DESCRIPTION
Based on the prof recommendation, we should not write any unit test that depend on the API key. Instead, we should just format the request to the API and verify that we receive valid response from the API. 